### PR TITLE
Add required kwargs to transitions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,8 +64,8 @@ model in your app, that inherits from a **FSMMixin** column ::
 
 To define FSM transitions on this class, create methods decorated with **@transition(..)** e.g. ::
 
-    @transition(Transition(src=['open', 'archived'], dest='published', permission=editor_permission))
-    def publish(self):
+    @transition(Transition(src=['open', 'archived'], dest='published', required=[], permission=editor_permission))
+    def publish(self, **kwargs):
         print('record published')
 
 

--- a/README.rst
+++ b/README.rst
@@ -64,9 +64,20 @@ model in your app, that inherits from a **FSMMixin** column ::
 
 To define FSM transitions on this class, create methods decorated with **@transition(..)** e.g. ::
 
-    @transition(Transition(src=['open', 'archived'], dest='published', required=[], permission=editor_permission))
+    @transition(Transition(
+        src=['open', 'archived'],
+        dest='published',
+        required=['id'],
+        permission=editor_permission))
     def publish(self, **kwargs):
         print('record published')
+
+Where **Transition** is defined as:
+
+  - **src**: record must be in one of the source states before transition could happen
+  - **dest**: target state of the transition
+  - **required**: a list of required ``**kwargs`` that must be passed to the ``@transition`` decorated function
+  - **permission**: currently logged user must have this permission to execute the transition
 
 
 REST API Usage

--- a/examples/models.py
+++ b/examples/models.py
@@ -16,18 +16,18 @@ def admin_permission(record):
 
 class ExampleRecord(FSMMixin, Record):
 
-    @transition(Transition(src=['closed'], dest='open'))
-    def open(self):
-        print('record opened')
+    @transition(Transition(src=['closed'], dest='open', required=['id']))
+    def open(self, **kwargs):
+        print('record {} opened'.format(kwargs.get('id')))
 
-    @transition(Transition(src=['open'], dest='closed'))
-    def close(self):
-        print('record closed')
+    @transition(Transition(src=['open'], dest='closed', required=['id']))
+    def close(self, **kwargs):
+        print('record {} closed'.format(kwargs.get('id')))
 
     @transition(Transition(src=['open', 'archived'], dest='published', permission=editor_permission))
-    def publish(self):
+    def publish(self, **kwargs):
         print('record published')
 
     @transition(Transition(src=['closed', 'published'], dest='archived', permission=admin_permission))
-    def archive(self):
+    def archive(self, **kwargs):
         print('record archived')

--- a/oarepo_fsm/decorators.py
+++ b/oarepo_fsm/decorators.py
@@ -6,7 +6,8 @@
 
 """OArepo FSM library for record state transitions."""
 
-from oarepo_fsm.errors import InvalidPermissionError, InvalidSourceStateError, MissingRequiredParameterError
+from oarepo_fsm.errors import InvalidPermissionError, \
+    InvalidSourceStateError, MissingRequiredParameterError
 
 
 def has_permission(f):

--- a/oarepo_fsm/errors.py
+++ b/oarepo_fsm/errors.py
@@ -40,6 +40,10 @@ class FSMException(RESTException):
         return json.dumps(body)
 
 
+class MissingRequiredParameterError(FSMException):
+    """Exception raised when required parameter is missing."""
+
+
 class DirectStateModificationError(FSMException):
     """Raised when a direct modification of record state is attempted."""
 

--- a/oarepo_fsm/views.py
+++ b/oarepo_fsm/views.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, print_function
 
 from functools import wraps
 
-from flask import current_app, jsonify, url_for
+from flask import current_app, jsonify, url_for, request
 from invenio_db import db
 from invenio_records_rest import current_records_rest
 from invenio_records_rest.views import pass_record
@@ -96,7 +96,7 @@ class FSMRecordActions(ContentNegotiatedMethodView):
             raise ActionNotAvailableError(action)
 
         # Invoke requested action for the current record
-        ua(record)
+        ua(record, **request.json)
         record.commit()
         db.session.commit()
         return self.make_response(

--- a/oarepo_fsm/views.py
+++ b/oarepo_fsm/views.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, print_function
 
 from functools import wraps
 
-from flask import current_app, jsonify, url_for, request
+from flask import current_app, jsonify, request, url_for
 from invenio_db import db
 from invenio_records_rest import current_records_rest
 from invenio_records_rest.views import pass_record

--- a/tests/test_kwargs.py
+++ b/tests/test_kwargs.py
@@ -9,11 +9,10 @@
 import pytest
 from flask_security import login_user
 
-from examples.models import ExampleRecord
 from oarepo_fsm.errors import MissingRequiredParameterError
 
 
-def test_transition_kwargs(record: ExampleRecord, users):
+def test_transition_kwargs(record, users):
     login_user(users['user'])
     assert record['state'] == 'closed'
     with pytest.raises(MissingRequiredParameterError):

--- a/tests/test_kwargs.py
+++ b/tests/test_kwargs.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CESNET.
+#
+# oarepo-fsm is free software; you can redistribute it and/or modify it under
+# the terms of the MIT License; see LICENSE file for more details.
+
+"""Test transition required kwargs."""
+import pytest
+from flask_security import login_user
+
+from examples.models import ExampleRecord
+from oarepo_fsm.errors import MissingRequiredParameterError
+
+
+def test_transition_kwargs(record: ExampleRecord, users):
+    login_user(users['user'])
+    assert record['state'] == 'closed'
+    with pytest.raises(MissingRequiredParameterError):
+        record.open()
+
+    assert record['state'] == 'closed'
+
+    record.open(id='abc')
+    with pytest.raises(MissingRequiredParameterError):
+        record.close()
+
+    record.close(id='cba')

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -20,15 +20,15 @@ def test_transition_permissions(record: ExampleRecord, users):
     with pytest.raises(InvalidPermissionError):
         record.archive()
 
-    record.open()
+    record.open(id='abc')
     with pytest.raises(InvalidPermissionError):
         record.publish()
-    record.close()
+    record.close(id=4)
 
     # User editor can publish, but not archive record
     login_user(users['editor'])
     assert record['state'] == 'closed'
-    record.open()
+    record.open(id='bca')
     record.publish()
     assert record['state'] == 'published'
 

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -18,12 +18,12 @@ from oarepo_fsm.errors import InvalidSourceStateError
 def test_record_transition(record: ExampleRecord):
     # Test state is changed when transition conditions are met
     assert record['state'] == 'closed'
-    record.open()
+    record.open(id='ccc')
     assert record['state'] == 'open'
 
     # Test state is not changed when transition conditions are not met
     with pytest.raises(InvalidSourceStateError):
-        record.open()
+        record.open(id='aaa')
     assert record['state'] == 'open'
 
 


### PR DESCRIPTION
This adds a posibility to specify mandatory `kwargs` that needs to be passed to transition functions.
Now every `@transition` decorated function expects to receive `**kwargs`.

To pass the `**kwargs` to transition function using the REST API, post them in JSON body of POST request like [this](https://github.com/oarepo/oarepo-fsm/pull/6/files#diff-be2cd2b9f012b69d8c1d26ecbd835280R112)

Related #3 