### PR TITLE
Transition ordering

### DIFF
--- a/oarepo_fsm/mixins.py
+++ b/oarepo_fsm/mixins.py
@@ -58,9 +58,13 @@ class FSMMixin(object):
         """
         if not getattr(cls, '_transitions', False):
             cls._transitions = {}
-            funcs = inspect.getmembers(cls, predicate=inspect.isfunction)
 
-            for act, fn in funcs:
+            # use dict directly and not inspect.getmembers as __dict__ seems to be sorted
+            # by definition order and getmembers alphabetically. Definition order is better
+            # because it enables to return the transitions in "logical" order.
+            for act, fn in cls.__dict__.items():
+                if not inspect.isfunction(fn):
+                    continue
                 if getattr(fn, '_fsm', False):
                     cls._transitions[act] = fn._fsm
 

--- a/oarepo_fsm/version.py
+++ b/oarepo_fsm/version.py
@@ -13,4 +13,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.3.1'
+__version__ = '1.3.2'

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -19,9 +19,10 @@ def test_record_rest_endpoints(app, json_headers):
     """Test REST API FSM endpoints."""
     url_rules = [r.rule for r in app.url_map.iter_rules()]
     url_endpoints = [r.endpoint for r in app.url_map.iter_rules()]
+    print(url_rules)
     assert '/records/<pid(recid,record_class="examples.models:ExampleRecord"):pid_value>' in url_rules
     assert '/records/<pid(recid,record_class="examples.models:ExampleRecord"):pid_value>/' \
-           '<any(archive,close,open,publish):transition>' in url_rules
+           '<any(open,close,publish,archive):transition>' in url_rules
     assert 'oarepo_fsm.recid_transitions' in url_endpoints
 
 


### PR DESCRIPTION
Transitions are returned in the order in which they are defined in source files